### PR TITLE
Phase 3: Make endpoint validation blocking (closes #11) — Droid-assisted PR

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -38,12 +38,11 @@ jobs:
     # moving.  Once legacy endpoints are removed in Phase 2 the guard can
     # be made blocking again (remove `continue-on-error` and `|| true`).
     - name: Validate API endpoints
-      continue-on-error: true
       run: |
         # Check if OpenAPI spec exists (it should be copied by regenerate-api-client workflow)
         if [ -f "api/openapi.yaml" ]; then
           echo "✅ OpenAPI spec found, validating endpoints..."
-          npm run validate:endpoints || true
+          npm run validate:endpoints
         else
           echo "⚠️ OpenAPI spec not found, skipping endpoint validation"
           echo "To enable validation, ensure api/openapi.yaml is present"

--- a/docs/API_ALIGNMENT_PHASE2_PLAN.md
+++ b/docs/API_ALIGNMENT_PHASE2_PLAN.md
@@ -1,6 +1,7 @@
 # API Alignment Roadmap  
 _AquaMind Frontend ↔ Backend • Phase 2 & 3 Planning_  
 Last updated: **2025-08-18**
+Status update (2025-08-21): CI now fails on endpoint validation errors; validator is clean on main.
 
 ---
 
@@ -46,7 +47,7 @@ _Total outstanding:_ **68** references.
 
 ## 4  Phase 3 — Final Cleanup (Post-Alignment)
 
-1. **Toggle CI** – make endpoint validation **blocking** (`continue-on-error: false`).
+1. **Toggle CI** – make endpoint validation **blocking** (`continue-on-error: false`) — DONE (this PR flips continue-on-error off).
 2. **Remove placeholders / mocks** introduced in Phase 1.
 3. **Generate client-only fetches** – mandate `ApiService` usage everywhere.
 4. **Delete redundant code** tied to removed “imaginary” features.
@@ -88,7 +89,7 @@ Use this matrix during triage meetings; record outcome in each GitHub issue.
 * ~~#8 Scenario dynamic endpoints implementation (completed in this PR)~~
 * ~~#9 Broodstock dashboard KPI backend spec (completed in this PR)~~
 * ~~#10 Batch analytics endpoint consolidation (closed by PR #19)~~
-* **#11** CI guard flip to blocking
+* ~~#11 CI guard flip to blocking (closed by this PR)~~
 * **#12** Documentation final pass
 
 (Replace `#xxx` with actual issue numbers once created.)


### PR DESCRIPTION
﻿Summary
- Flip CI to fail on endpoint validation errors now that invalid endpoints are 0.
- Minimal change: remove continue-on-error and trailing `|| true` from the "Validate API endpoints" step in `.github/workflows/frontend-ci.yml`.

Before/After

Before:
```yaml
- name: Validate API endpoints
  continue-on-error: true
  run: |
    if [ -f "api/openapi.yaml" ]; then
      npm run validate:endpoints || true
    fi
```

After:
```yaml
- name: Validate API endpoints
  run: |
    if [ -f "api/openapi.yaml" ]; then
      npm run validate:endpoints
    fi
```

Local verification (Node 24.x)
- npm run type-check → OK
- npm run validate:endpoints → OK (0 invalid; dynamic paths skipped)
- npm run test:ci → OK (17 files, 41 tests passed)

Docs
- Updated `docs/API_ALIGNMENT_PHASE2_PLAN.md` Phase 3 item 1 to mark CI guard as DONE and denote closing #11.

Notes
- No changes to validator script, infra/debug fetch usage, or generated client internals.

This is a Droid-assisted PR.
